### PR TITLE
Update shellbug.py

### DIFF
--- a/shellbug.py
+++ b/shellbug.py
@@ -210,6 +210,7 @@ def run_sc(SC, SCOUNT, STACK_ADDRESS):
 SC = sys.argv[1]
 SC = sys.argv[1].replace("\\x", "")
 SC = SC.replace("0x", "")
+SC = SC.replace("'", "")
 SC = [SC[x:x + 2] for x in range(0, len(SC), 2)]
 SC = "".join([chr(int(x, 16)) for x in SC])
 


### PR DESCRIPTION
Fix the error "ValueError: invalid literal for int() with base 16: "'4"  " when running the example:
`python shellbug.py '\x40\x49\x81\xC6\x41\x00\x00\x01\x68\x48\x65\x6C\x6C\x39\xC8\x74\xF0\x31\xC9\xC7\x06\x2D\x62\x15\x2D\x80\x36\x42\x46\x47\x83\xFF\x04\x7E\xF6\x31\xF6\x81\xC6\x45\x00\x00\x01\xC7\x06\x30\x2E\x26\x00\x58\xA3\x3D\x00\x00\x01\x31\xFF\xEB\xDE'
`
